### PR TITLE
Nd randomize playlist

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import './App.scss';
-import { Link, Route, NavLink} from 'react-router-dom';
+import { Route } from 'react-router-dom';
 
 import Header from '../Header/Header';
 import GenresList from '../GenresList/GenresList';
@@ -24,8 +24,8 @@ class App extends Component<{}> {
 					return (
 						<section className="testing">
 							<GenresList />
-							<PlaylistContainer playlistType={'custom-playlist'} /> {/* Custom Playlist */}
-							<PlaylistContainer playlistType={'generated-playlist'} /> {/* Generated Playlist */}
+							<PlaylistContainer playlistType={'custom-playlist'} />
+							<PlaylistContainer playlistType={'generated-playlist'} />
 						</section>
 					)
 				}} />

--- a/src/GeneratedPlaylists/GeneratedPlaylist.tsx
+++ b/src/GeneratedPlaylists/GeneratedPlaylist.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 
+import { getPlaylist } from '../apiCalls'
+
+const getSongsByGenre = () => {
+  // getPlaylist('hip+hop').then(data => console.log(data));
+}
+
 function GeneratedPlaylist() {
+  console.log(getSongsByGenre());
   return (
     <section className='generated-playlist'>
     </section>

--- a/src/PlaylistContainer/PlaylistContainer.tsx
+++ b/src/PlaylistContainer/PlaylistContainer.tsx
@@ -1,23 +1,31 @@
-import React from 'react'
+import React from 'react';
 
-const displayPlaylist = (playlistType: string) => {
-  if (playlistType === 'saved-playlist') {
-    return <h1>Saved Playlist</h1>
-  }
-  if (playlistType === 'generated-playlist') {
-    return <h1>Generated Playlist</h1>
-  }
-  if (playlistType === 'custom-playlist') {
-    return <h1>Custom Playlist</h1>
-  }
+import GeneratedPlaylist from '../GeneratedPlaylists/GeneratedPlaylist';
+
+enum PlaylistTypes {
+	SavedPlaylist = 'saved-playlist',
+	GeneratedPlaylist = 'generated-playlist',
+	CustomPlaylist = 'custom-playlist',
 }
 
+const displayPlaylist = (playlistType: PlaylistTypes) => {
+	if (playlistType === PlaylistTypes.SavedPlaylist) {
+		return <h1>Saved Playlist</h1>;
+	}
+	if (playlistType === PlaylistTypes.GeneratedPlaylist) {
+		return <GeneratedPlaylist />;
+	}
+	if (playlistType === PlaylistTypes.CustomPlaylist) {
+		return <h1>Custom Playlist</h1>;
+	}
+};
+
 function PlaylistContainer(props: any) {
-  return (
-    <section className='playlist-container'>
-      { displayPlaylist(props.playlistType) }
-    </section>
-  )
+	return (
+		<section className='playlist-container'>
+			{displayPlaylist(props.playlistType)}
+		</section>
+	);
 }
 
 export default PlaylistContainer;

--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -7,7 +7,7 @@ export const getGenres = () => {
 
 export const getPlaylist = (genre: string) => {
   return (
-    fetch(`http://ws.audioscrobbler.com/2.0/?method=tag.gettoptracks&tag=${genre}&api_key=${process.env.REACT_APP_LASTFM_APIKEY}&format=json`)
+    fetch(`http://ws.audioscrobbler.com/2.0/?method=tag.gettoptracks&tag=${genre}&api_key=${process.env.REACT_APP_LASTFM_APIKEY}&limit=300&format=json`)
       .then(response => response.json())
   )
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,3 +18,13 @@ interface AlbumTrack {
   url: string
 }
 
+export interface CleanedAlbumTrack {
+  mbid: string,
+  artist: {
+    name: string,
+    artistUrl: string
+  },
+  duration: string,
+  songName: string,
+  songUrl: string,
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,3 +28,16 @@ export interface CleanedAlbumTrack {
   songName: string,
   songUrl: string,
 }
+
+export const cleanGenreTrackData = (track: AlbumTrack): CleanedAlbumTrack => {
+  return {
+    mbid: track.mbid,
+    artist: {
+      name: track.artist.name,
+      artistUrl: track.artist.url
+    },
+    duration: track.duration,
+    songName: track.name,
+    songUrl: track.url
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,20 @@
+interface AlbumTrack {
+  "@attr": {
+    rank: string
+  },
+  artist: {
+    name: string,
+    mbid: string,
+    url: string,
+  }
+  duration: string,
+  image: object[],
+  mbid: string,
+  name: string,
+  streamable: {
+    "#text": string,
+    fulltrack: string
+  }
+  url: string
+}
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,3 +41,13 @@ export const cleanGenreTrackData = (track: AlbumTrack): CleanedAlbumTrack => {
     songUrl: track.url
   }
 }
+
+export const randomizeSongs = (playlist: CleanedAlbumTrack[]) => {
+  const newSongsArray = [];
+  const iteration: number = playlist.length;
+  for (let i = 0; i < iteration; i++) {
+    let getRandomIndex = Math.floor(Math.random() * playlist.length);
+    newSongsArray.push(playlist.splice(getRandomIndex, 1)[0])
+  }
+  return newSongsArray;
+}


### PR DESCRIPTION
### What’s this PR do?  

- Adds an utils.js file that can be used to compliment certain functions inside of the app.
- utils.js has an interface for how the data from the last.fm API should come in.
- utils.js has an interface for how the data within Genrefy should be used (rather than using a lot of unused raw data from last.fm API)
- utils.js has the `cleanGenreTrackData` method that will take the data from the last.fm API and turn it into the usable data we want.
- utils.js has the `randomizeSongs` method that will randomize the playlist from `cleanGenreTrackData` and make sure it's not return the same results every time.
- added `enum PlaylistTypes` inside PlaylistContainer.tsx file to ensure that only those 3 strings are used when dynamically display a certain play list to the page.
- added a limit of 300 results, instead of 50, when doing the fetch call from last.fm for more variety.
 
### Where should the reviewer start?  

- Git pull this branch.
- Navigate to PlaylistContainer.tsx file to see enum.
- Navigate to apiCalls.js to see new limit on last.fm fetch call.
- Navigate to utils.js to see the new utils.js file and methods.
 
### How should this be manually tested?  

- Run `npm install` if this is the first time pulling from this repo.
- Run `npm start` to open app on localhost:3000.
- Uncomment `getPlaylist` method on line 6 in GeneratedPlaylist.tsx to see if the fetch call logs the data correctly in terminal. (currently commented to reduce api calls with hot reloading and hitting a limit).
- Make an array of how ever many length you want and pass it into the `randomizeSongs` method in utils.js and ensure it is randomizing as intended.
 
### Any background context you want to provide?  

- Testing `randomsizeSongs` with an array of 10 numbers. Didn't try one larger or with the songs from the API yet.

 
### What are the relevant tickets?  

- closes #36 
- closes #31 
 
### Screenshots (if appropriate)  

- N/A
 
### Questions: 

- N/A