### PR TITLE
Nd genre component

### DIFF
--- a/src/Genre/Genre.test.tsx
+++ b/src/Genre/Genre.test.tsx
@@ -5,4 +5,22 @@ import '@testing-library/jest-dom';
 
 import Genre from './Genre';
 
+const mockSelectedGenre = jest.fn();
 
+describe('Genre', () => {
+	beforeEach(() =>
+		render(
+			<Genre updateSelectedGenre={mockSelectedGenre} genre={'jesus funk'} />
+		)
+	);
+	test('should render a genre to the screen', () => {
+		expect(screen.getByText('jesus funk')).toBeInTheDocument();
+	});
+
+	test('should render another genre', () => {
+		render(
+			<Genre updateSelectedGenre={mockSelectedGenre} genre={'kraut mallet'} />
+		);
+		expect(screen.getByText('kraut mallet')).toBeInTheDocument();
+	});
+});

--- a/src/Genre/Genre.test.tsx
+++ b/src/Genre/Genre.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import Genre from './Genre';
+
+

--- a/src/Genre/Genre.test.tsx
+++ b/src/Genre/Genre.test.tsx
@@ -23,4 +23,10 @@ describe('Genre', () => {
 		);
 		expect(screen.getByText('kraut mallet')).toBeInTheDocument();
 	});
+
+	test('should update selected genre when clicked', () => {
+		userEvent.click(screen.getByRole('heading', { name: 'jesus funk' }));
+		expect(mockSelectedGenre).toHaveBeenCalledTimes(1);
+		expect(mockSelectedGenre).toHaveBeenCalledWith('jesus funk');
+	});
 });

--- a/src/Genre/Genre.tsx
+++ b/src/Genre/Genre.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
 
-function Genre() {
+interface IProps {
+  updateSelectedGenre: (genre: string) => void;
+  genre: string;
+}
+
+function Genre(props: IProps) {
+  console.log(props);
   return (
     <section className='genre'>
-      <h1>Genre</h1>
+      <h1>{props.genre}</h1>
     </section>
   )
 }

--- a/src/Genre/Genre.tsx
+++ b/src/Genre/Genre.tsx
@@ -10,7 +10,7 @@ function Genre(props: IProps) {
 		<section className='genre'>
 			<h1
 				onClick={event =>
-					props.updateSelectedGenre(event.currentTarget.innerText)
+					props.updateSelectedGenre(event.currentTarget.innerHTML)
 				}>
 				{props.genre}
 			</h1>

--- a/src/Genre/Genre.tsx
+++ b/src/Genre/Genre.tsx
@@ -1,17 +1,21 @@
-import React from 'react'
+import React from 'react';
 
 interface IProps {
-  updateSelectedGenre: (genre: string) => void;
-  genre: string;
+	updateSelectedGenre: (genre: string) => void;
+	genre: string;
 }
 
 function Genre(props: IProps) {
-  console.log(props);
-  return (
-    <section className='genre'>
-      <h1>{props.genre}</h1>
-    </section>
-  )
+	return (
+		<section className='genre'>
+			<h1
+				onClick={event =>
+					props.updateSelectedGenre(event.currentTarget.innerText)
+				}>
+				{props.genre}
+			</h1>
+		</section>
+	);
 }
 
 export default Genre;

--- a/src/GenresList/GenresList.tsx
+++ b/src/GenresList/GenresList.tsx
@@ -1,11 +1,13 @@
 import React, { Component } from 'react'
 import { getGenres } from '../apiCalls'
 
+import Genre from '../Genre/Genre'
+
 // come back and properly type setAppGenre
 interface IProps {setAppGenre: (genre: string) => void}
 interface IState { genres: string[] }
 
-class Genre extends Component<IProps, IState> {  
+class GenreList extends Component<IProps, IState> {  
   constructor(props: any) {
     super(props)
     this.state = {
@@ -43,4 +45,4 @@ class Genre extends Component<IProps, IState> {
   }
 }
 
-export default Genre;
+export default GenreList;

--- a/src/GenresList/GenresList.tsx
+++ b/src/GenresList/GenresList.tsx
@@ -24,14 +24,14 @@ class GenreList extends Component<IProps, IState> {
     .then(data => this.setState({ genres: data}))
   }
 
-  updateSelectedGenre = (event: React.MouseEvent<HTMLHeadingElement>) => {
-    this.props.setAppGenre(event.currentTarget.innerHTML)
+  updateSelectedGenre = (genre: string) => {
+    this.props.setAppGenre(genre)
   }
 
   renderGenres = () => {
     return this.state.genres.map((genre, i) => {
       return (
-          <h3 key={i} onClick={this.updateSelectedGenre}>{genre}</h3>
+        <Genre key={i} updateSelectedGenre={this.updateSelectedGenre} genre={genre} />
       )
     })
   }


### PR DESCRIPTION
### What’s this PR do?  
- Changes the genre being rendered as an H3 tag inside GenresList to using the Genre component.
- Updates a bug where GenresList file was still export as Genre.
- Display the Genre component to the page.
- Updates the onClick event to update the Genre in App's state to be triggered from a method passed down through GenresList into Genre component.
 
### Where should the reviewer start?  
- Git pull this branch.
- Navigate to GenreList.tsx and Genre.tsx files

### How should this be manually tested?  
- `npm start` navigate to localhost:3000
- Ensure all genres are rendering as a Genre component instead of a H3
- Click on a genre and check App's selectedGenre state to ensure it updates.
 
### Any background context you want to provide?  
- Will update Genre to become an actual graphic when doing the SCSS update.
 
### What are the relevant tickets?  
- closes #32 
- closes #34 
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A