### PR TITLE
Nd refactor playlist to app

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -6,10 +6,14 @@ import Header from '../Header/Header';
 import GenresList from '../GenresList/GenresList';
 import PlaylistContainer from '../PlaylistContainer/PlaylistContainer';
 
+import { getPlaylist } from '../apiCalls';
+
+import { CleanedAlbumTrack } from '../utils';
+
 interface IProps {}
 interface IState {
 	genres: [],
-	playlists: [],
+	playlists: [CleanedAlbumTrack[]] | [],
 	selectedGenre: string
 }
 
@@ -19,8 +23,13 @@ class App extends Component<IProps, IState> {
 		this.state = {
 			genres: [],
 			playlists: [],
-			selectedGenre: ""
+			selectedGenre: "hip hop"
 		}
+	}
+
+	componentDidMount = () => {
+		getPlaylist(this.state.selectedGenre)
+		.then(data => this.setState({ playlists: [[...data]] }));
 	}
 
 	setAppGenre = (genre: string) => {
@@ -35,9 +44,9 @@ class App extends Component<IProps, IState> {
 				<Route exact path='/' render={() => {
 					return (
 						<section className="testing">
-							<GenresList setAppGenre={this.setAppGenre}/>
-							<PlaylistContainer playlistType={'generated-playlist'} selectedGenre={this.state.selectedGenre}/>
-							<PlaylistContainer playlistType={'custom-playlist'} />
+							<GenresList setAppGenre={this.setAppGenre} />
+							<PlaylistContainer playlistType={'generated-playlist'} selectedGenre={this.state.selectedGenre} />
+							{/* <PlaylistContainer playlistType={'custom-playlist'} /> */}
 						</section>
 					)
 				}} />

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -45,12 +45,12 @@ class App extends Component<IProps, IState> {
 					return (
 						<section className="testing">
 							<GenresList setAppGenre={this.setAppGenre} />
-							<PlaylistContainer playlistType={'generated-playlist'} selectedGenre={this.state.selectedGenre} />
+							<PlaylistContainer playlistType={'generated-playlist'} selectedGenre={this.state.selectedGenre} playlists={this.state.playlists} />
 							{/* <PlaylistContainer playlistType={'custom-playlist'} /> */}
 						</section>
 					)
 				}} />
-				<Route path='/saved-playlist' render={() => <PlaylistContainer playlistType={'saved-playlist'} />} />
+				<Route path='/saved-playlist' render={() => <PlaylistContainer playlistType={'saved-playlist'} selectedGenre={this.state.selectedGenre} playlists={this.state.playlists} />} />
 			</div>
 		)
 	}

--- a/src/GeneratedPlaylists/GeneratedPlaylist.tsx
+++ b/src/GeneratedPlaylists/GeneratedPlaylist.tsx
@@ -1,44 +1,25 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { CleanedAlbumTrack } from '../utils'
-import { getPlaylist } from '../apiCalls'
 
-interface IProps { selectedGenre: string }
-interface IState { songs: CleanedAlbumTrack[] }
+interface IProps { selectedGenre: string, playlist: CleanedAlbumTrack[] }
 
-class GeneratedPlaylist extends Component<IProps, IState> {
-  constructor(props: IProps) {
-    super(props)
-    this.state = {
-      songs: [],
-    }
-  }
+const displaySongs = (playlist: CleanedAlbumTrack[]) => {
+  return playlist.reduce((finalSongs: JSX.Element[], currentSong, index: number): JSX.Element[] => {
+      const songToDisplay = 
+        <section key={index}>
+          <h3>{currentSong.songName}</h3>
+        </section>;
+      finalSongs.push(songToDisplay)
+    return finalSongs
+  }, [])
+}
 
-  componentDidMount = () => {
-    getPlaylist(this.props.selectedGenre)
-    .then(data => this.setState({ songs: data }));
-  }
-
-  displaySongs = () => {
-    return this.state.songs.reduce((finalSongs: JSX.Element[], currentSong, index: number): JSX.Element[] => {
-      if (index < 10) {
-        const songToDisplay = 
-          <section key={index}>
-            <h3>{currentSong.songName}</h3>
-          </section>;
-        finalSongs.push(songToDisplay)
-      }
-      return finalSongs
-    }, [])
-  }
-
-  render() {
-    const songsToDisplay = this.displaySongs()
-    return (
-      <section className='generated-playlist'>
-        {songsToDisplay}
-      </section>
-    )
-  }
+const GeneratedPlaylist = (props: IProps) => {
+  return (
+    <section className="generated-playlist">
+      {displaySongs(props.playlist)}
+    </section>
+  )
 }
 
 export default GeneratedPlaylist;

--- a/src/GeneratedPlaylists/GeneratedPlaylist.tsx
+++ b/src/GeneratedPlaylists/GeneratedPlaylist.tsx
@@ -2,20 +2,19 @@ import React, { Component } from 'react'
 import { CleanedAlbumTrack } from '../utils'
 import { getPlaylist } from '../apiCalls'
 
-interface IProps {}
-interface IState { songs: CleanedAlbumTrack[],  selectedGenre: string }
+interface IProps { selectedGenre: string }
+interface IState { songs: CleanedAlbumTrack[] }
 
 class GeneratedPlaylist extends Component<IProps, IState> {
-  constructor(props: any) {
+  constructor(props: IProps) {
     super(props)
     this.state = {
       songs: [],
-      selectedGenre: ""
     }
   }
 
   componentDidMount = () => {
-    getPlaylist(this.state.selectedGenre)
+    getPlaylist(this.props.selectedGenre)
     .then(data => this.setState({ songs: data }));
   }
 

--- a/src/Genre/Genre.tsx
+++ b/src/Genre/Genre.tsx
@@ -14,6 +14,12 @@ function Genre(props: IProps) {
 				}>
 				{props.genre}
 			</h1>
+			<h6
+				onClick={event =>
+					props.updateSelectedGenre(event.currentTarget.innerHTML)
+				}>
+				Rock
+			</h6>
 		</section>
 	);
 }

--- a/src/PlaylistContainer/PlaylistContainer.tsx
+++ b/src/PlaylistContainer/PlaylistContainer.tsx
@@ -3,19 +3,29 @@ import SavedPlaylist from '../SavedPlaylists/SavedPlaylist';
 import GeneratedPlaylist from '../GeneratedPlaylists/GeneratedPlaylist';
 // import CustomPlaylist from '../CustomPlaylists/CustomPlaylist';
 
+import { CleanedAlbumTrack } from '../utils';
+
+interface IProps {
+	playlistType: string,
+	selectedGenre: string,
+	playlists: [CleanedAlbumTrack[]] | []
+}
+
 enum PlaylistTypes {
 	SavedPlaylist = 'saved-playlist',
 	GeneratedPlaylist = 'generated-playlist',
 	// CustomPlaylist = 'custom-playlist',
 }
 
-function PlaylistContainer(props: any) {
-	const displayPlaylist = (playlistType: PlaylistTypes) => {
+function PlaylistContainer(props: IProps) {
+	const displayPlaylist = (playlistType: string) => {
 		if (playlistType === PlaylistTypes.SavedPlaylist) {
 			return <SavedPlaylist />;
 		}
-		if (playlistType === PlaylistTypes.GeneratedPlaylist) {
-			return <GeneratedPlaylist selectedGenre={props.selectedGenre}/>;
+		if (playlistType === PlaylistTypes.GeneratedPlaylist && props.playlists.length) {
+			return props.playlists.map((playlist: CleanedAlbumTrack[], index: number) => {
+				return <GeneratedPlaylist key={index} selectedGenre={props.selectedGenre} playlist={playlist} />
+			})
 		}
 		// if (playlistType === PlaylistTypes.CustomPlaylist) {
 		// 	return <CustomPlaylist />;

--- a/src/PlaylistContainer/PlaylistContainer.tsx
+++ b/src/PlaylistContainer/PlaylistContainer.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
 import SavedPlaylist from '../SavedPlaylists/SavedPlaylist';
 import GeneratedPlaylist from '../GeneratedPlaylists/GeneratedPlaylist';
-import CustomPlaylist from '../CustomPlaylists/CustomPlaylist';
+// import CustomPlaylist from '../CustomPlaylists/CustomPlaylist';
 
 enum PlaylistTypes {
 	SavedPlaylist = 'saved-playlist',
 	GeneratedPlaylist = 'generated-playlist',
-	CustomPlaylist = 'custom-playlist',
+	// CustomPlaylist = 'custom-playlist',
 }
 
-const displayPlaylist = (playlistType: PlaylistTypes) => {
-	if (playlistType === PlaylistTypes.SavedPlaylist) {
-		return <SavedPlaylist />;
-	}
-	if (playlistType === PlaylistTypes.GeneratedPlaylist) {
-		return <GeneratedPlaylist />;
-	}
-	if (playlistType === PlaylistTypes.CustomPlaylist) {
-		return <CustomPlaylist />;
-	}
-};
-
 function PlaylistContainer(props: any) {
+	const displayPlaylist = (playlistType: PlaylistTypes) => {
+		if (playlistType === PlaylistTypes.SavedPlaylist) {
+			return <SavedPlaylist />;
+		}
+		if (playlistType === PlaylistTypes.GeneratedPlaylist) {
+			return <GeneratedPlaylist selectedGenre={props.selectedGenre}/>;
+		}
+		// if (playlistType === PlaylistTypes.CustomPlaylist) {
+		// 	return <CustomPlaylist />;
+		// }
+	};
+
 	return (
 		<section className='playlist-container'>
 			{displayPlaylist(props.playlistType)}

--- a/src/PlaylistContainer/PlaylistContainer.tsx
+++ b/src/PlaylistContainer/PlaylistContainer.tsx
@@ -17,24 +17,24 @@ enum PlaylistTypes {
 	// CustomPlaylist = 'custom-playlist',
 }
 
-function PlaylistContainer(props: IProps) {
-	const displayPlaylist = (playlistType: string) => {
-		if (playlistType === PlaylistTypes.SavedPlaylist) {
-			return <SavedPlaylist />;
-		}
-		if (playlistType === PlaylistTypes.GeneratedPlaylist && props.playlists.length) {
-			return props.playlists.map((playlist: CleanedAlbumTrack[], index: number) => {
-				return <GeneratedPlaylist key={index} selectedGenre={props.selectedGenre} playlist={playlist} />
-			})
-		}
-		// if (playlistType === PlaylistTypes.CustomPlaylist) {
-		// 	return <CustomPlaylist />;
-		// }
-	};
+const displayPlaylist = (playlistType: string, playlists: [CleanedAlbumTrack[]] | [], selectedGenre: string) => {
+	if (playlistType === PlaylistTypes.SavedPlaylist) {
+		return <SavedPlaylist />;
+	}
+	if (playlistType === PlaylistTypes.GeneratedPlaylist && playlists.length) {
+		return playlists.map((playlist: CleanedAlbumTrack[], index: number) => {
+			return <GeneratedPlaylist key={index} selectedGenre={selectedGenre} playlist={playlist} />
+		})
+	}
+	// if (playlistType === PlaylistTypes.CustomPlaylist) {
+	// 	return <CustomPlaylist />;
+	// }
+};
 
+function PlaylistContainer(props: IProps) {
 	return (
 		<section className='playlist-container'>
-			{displayPlaylist(props.playlistType)}
+			{displayPlaylist(props.playlistType, props.playlists, props.selectedGenre)}
 		</section>
 	);
 }

--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -15,7 +15,8 @@ export const getPlaylist = (genre: string) => {
         const CleanedGenreTrackData: CleanedAlbumTrack[] = data.tracks.track.map((song: AlbumTrack)  => {
           return cleanGenreTrackData(song)
         })
-        return randomizeSongs(CleanedGenreTrackData)
+        const randomPlaylist = randomizeSongs(CleanedGenreTrackData);
+        return randomPlaylist.filter((_playlist, index) => index < 10);
       })
   )
 }


### PR DESCRIPTION
### What’s this PR do?  
- Refactors instances of state (selectedGenre) that were in multiple states on multiple components to only be in App's state that gets passed down as props.
- Refactors playlist state that was inside GeneratedPlaylist component to App's playlists state.
- Refactors GeneratedPlaylist into a functional component that receives the playlists from App's state.
- Adds another 'Rock' Genre that is printed with every instance of a genre purely for testing purposes in the next branch.
- Comments out all instances of CustomPlaylist as it may not make it into final build. If we make it in time, we can uncomment them or delete before final submission.
- Refactored getPlaylist in apiCalls.ts to only return 10 songs.
 
### Where should the reviewer start?  
- Git pull this branch.
- Operate in files App, GeneratedPlaylist, Genre, PlaylistContainer, apiCalls.
 
### How should this be manually tested?  
- Run `npm start` and open localhost:3000
- Refresh the page and ensure that it is getting different genres and playlists printing on the bottom of the page each time.
- Open up dev tools React components and make sure the state for playlist and genres inside of app.
 
### Any background context you want to provide?  
- Inside of PlaylistContainer, we had to use a union type for the playlists inside interface IProps. Typescript currently has bug where it has a hard time detecting specific union types (mostly revolving around arrays) and was throwing an error when trying to iterate over a legitimate array if it is including in the union type. To handle this, in the conditional when rendering GeneratedPlaylists, we have to do a length check on playlists as well.
 
### What are the relevant tickets?  
- closes #50
- closes #51
- closes #52
- closes #53
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A