### PR TITLE
Bm display playlists onclick

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -6,14 +6,14 @@ import Header from '../Header/Header';
 import GenresList from '../GenresList/GenresList';
 import PlaylistContainer from '../PlaylistContainer/PlaylistContainer';
 
-import { getPlaylist } from '../apiCalls';
+import { getPlaylist, getGenres } from '../apiCalls';
 
 import { CleanedAlbumTrack } from '../utils';
 
 interface IProps {}
 interface IState {
 	genres: [],
-	playlists: [CleanedAlbumTrack[]] | [],
+	playlists: any,
 	selectedGenre: string
 }
 
@@ -23,17 +23,19 @@ class App extends Component<IProps, IState> {
 		this.state = {
 			genres: [],
 			playlists: [],
-			selectedGenre: "hip hop"
+			selectedGenre: ""
 		}
 	}
 
 	componentDidMount = () => {
-		getPlaylist(this.state.selectedGenre)
-		.then(data => this.setState({ playlists: [[...data]] }));
+		getGenres()
+    .then(data => this.setState({ genres: data}))
 	}
 
 	setAppGenre = (genre: string) => {
 		this.setState({ selectedGenre: genre })
+		getPlaylist(this.state.selectedGenre)
+		.then(data => this.setState({ playlists: [...this.state.playlists, [...data]] }));
 	}
 	
 	render() {
@@ -44,7 +46,7 @@ class App extends Component<IProps, IState> {
 				<Route exact path='/' render={() => {
 					return (
 						<section className="testing">
-							<GenresList setAppGenre={this.setAppGenre} />
+							<GenresList setAppGenre={this.setAppGenre} selectedGenre={this.state.selectedGenre} genres={this.state.genres} />
 							<PlaylistContainer playlistType={'generated-playlist'} selectedGenre={this.state.selectedGenre} playlists={this.state.playlists} />
 							{/* <PlaylistContainer playlistType={'custom-playlist'} /> */}
 						</section>

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -13,7 +13,7 @@ import { CleanedAlbumTrack } from '../utils';
 interface IProps {}
 interface IState {
 	genres: [],
-	playlists: any,
+	playlists: CleanedAlbumTrack[][] | [],
 	selectedGenre: string
 }
 

--- a/src/GenresList/GenresList.tsx
+++ b/src/GenresList/GenresList.tsx
@@ -1,48 +1,27 @@
-import React, { Component } from 'react'
-import { getGenres } from '../apiCalls'
+import React from 'react'
 
 import Genre from '../Genre/Genre'
 
-// come back and properly type setAppGenre
-interface IProps {setAppGenre: (genre: string) => void}
-interface IState { genres: string[] }
+interface IProps {setAppGenre: (genre: string) => void, genres: string[], selectedGenre: string}
 
-class GenreList extends Component<IProps, IState> {  
-  constructor(props: any) {
-    super(props)
-    this.state = {
-      genres: []
-    }
+function GenresList(props: IProps) {  
+  const updateSelectedGenre = (genre: string) => {
+    props.setAppGenre(genre)
   }
-
-  componentDidMount() {
-    this.setGenres()
-  }
-
-  setGenres = () => {
-    getGenres()
-    .then(data => this.setState({ genres: data}))
-  }
-
-  updateSelectedGenre = (genre: string) => {
-    this.props.setAppGenre(genre)
-  }
-
-  renderGenres = () => {
-    return this.state.genres.map((genre, i) => {
+  
+  const renderGenres = () => {
+    return props.genres.map((genre: string, i: number) => {
       return (
-        <Genre key={i} updateSelectedGenre={this.updateSelectedGenre} genre={genre} />
+        <Genre key={i} updateSelectedGenre={updateSelectedGenre} genre={genre} />
       )
     })
   }
 
-  render() {
-    return (
-      <section>
-        {this.renderGenres()}
-      </section>
-    )
-  }
+  return (
+    <section>
+      {renderGenres()}
+    </section>
+  )
 }
 
-export default GenreList;
+export default GenresList;

--- a/src/PlaylistContainer/PlaylistContainer.tsx
+++ b/src/PlaylistContainer/PlaylistContainer.tsx
@@ -8,7 +8,7 @@ import { CleanedAlbumTrack } from '../utils';
 interface IProps {
 	playlistType: string,
 	selectedGenre: string,
-	playlists: [CleanedAlbumTrack[]] | []
+	playlists: CleanedAlbumTrack[][] | []
 }
 
 enum PlaylistTypes {
@@ -17,7 +17,7 @@ enum PlaylistTypes {
 	// CustomPlaylist = 'custom-playlist',
 }
 
-const displayPlaylist = (playlistType: string, playlists: [CleanedAlbumTrack[]] | [], selectedGenre: string) => {
+const displayPlaylist = (playlistType: string, playlists: any, selectedGenre: string) => {
 	if (playlistType === PlaylistTypes.SavedPlaylist) {
 		return <SavedPlaylist />;
 	}


### PR DESCRIPTION
### What’s this PR do?  
* Renders playlists when clicking various genres
* Refactors GenresList to functional component
* Moves apiCalls functions to componentDidMount and setAppGenre
* Fixes type error for App.state.playlist, changed playlist type to any in PlaylistContainer
 
### Where should the reviewer start?  
src/GeneratedPlaylists
src/App
src/GenresList

### How should this be manually tested?  
npm start, click on a few playlists and see that they are rendered as separate playlists on the DOM
 
### Any background context you want to provide?  
props.playlists in playlistContainer type is currently `any` because union types don't work with map. However, the playlists have already been typed in App before passing them into PlaylistContainer, so I feel ok with this change.
 
### What are the relevant tickets?  
Closes #55 
Closes #56
 
### Screenshots (if appropriate)  
N/A
 
### Questions: 
N/A