### PR TITLE
Nd parse genre playlist

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -33,9 +33,24 @@ class App extends Component<IProps, IState> {
 	}
 
 	setAppGenre = (genre: string) => {
-		this.setState({ selectedGenre: genre })
-		getPlaylist(this.state.selectedGenre)
+		this.setState({ selectedGenre: genre });
+		getPlaylist(genre)
 		.then(data => this.setState({ playlists: [...this.state.playlists, [...data]] }));
+	}
+
+	parseGenreForFetch = (genre: string) => {
+		const fillerWordsToRemove = /(the |and |of |\/| |ism)+/;
+		const parseGenreArray = genre.split(fillerWordsToRemove);
+		if (parseGenreArray.includes('')) {
+			const index = parseGenreArray.indexOf('');
+			parseGenreArray.splice(index, 1);
+		}
+		parseGenreArray.forEach((genre, index) => {
+			if (genre.match(fillerWordsToRemove) || genre === '') {
+				parseGenreArray.splice(index, 1);
+			}
+		});
+		return parseGenreArray;
 	}
 	
 	render() {

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -34,7 +34,8 @@ class App extends Component<IProps, IState> {
 
 	setAppGenre = (genre: string) => {
 		this.setState({ selectedGenre: genre });
-		getPlaylist(genre)
+		const splitGenreArray = this.parseGenreForFetch(genre);
+		getPlaylist(splitGenreArray)
 		.then(data => this.setState({ playlists: [...this.state.playlists, [...data]] }));
 	}
 

--- a/src/Genre/Genre.tsx
+++ b/src/Genre/Genre.tsx
@@ -14,12 +14,6 @@ function Genre(props: IProps) {
 				}>
 				{props.genre}
 			</h1>
-			<h6
-				onClick={event =>
-					props.updateSelectedGenre(event.currentTarget.innerHTML)
-				}>
-				Rock
-			</h6>
 		</section>
 	);
 }


### PR DESCRIPTION
### What’s this PR do?  
- Removes the consistent rock genre from being printed.
- Refactors getPlaylist apiCall into a Promise.all from parsed Genre string when a clicks
- Refactors setAppGenre in App.tsx to pass getPlaylist an array of genres instead of a single large genre.
- Adds parseGenreForFetch method to parse the genre string into a more readable format for API call to return consisten results.
- Refactors API call to return 100 tracks per genre fetch instead of 300.
- Refactors filter after combining all the genres songs together to return 15 results per playlist instead of 10.
 
### Where should the reviewer start?  
- Git pull this branch
- Navigate to App.tsx, Genre.tsx and apiCalls.ts files
 
### How should this be manually tested?  
- Run `npm install` if this is your first time working on this repo
- Run `npm start` to open local server, navigate to localhost:3000
- Should see a list of genres that gets printed out on the page. Ensure rock is not printed for every genre that is printed.
- Click on a genre heading tag to invoke the fetch call.
- Check at the bottom of the page to see if 15 songs have been returned from that fetch call.
- Click on another genre without reloading to ensure 30 songs are now displayed on the page.
 
### Any background context you want to provide?  
- The parseGenreForFetch will parse the genre and split it at specific words or spacing. This method will then return an array of each individual genre that is easier for the API to return songs with.
- The additional `.includes()` conditional check inside `parseGenreForFetch` is to get rid of any strings that get split at the end (EX: ism) that JS will leave an empty string inside of the array.
 
### What are the relevant tickets?  
- closes #30
- closes #58
- closes #59
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A