### PR TITLE
Nd genre styling

### DIFF
--- a/src/App/App.scss
+++ b/src/App/App.scss
@@ -5,6 +5,7 @@
   align-items: center;
   background: url(../images/main-background.jpg) no-repeat center;
   background-size: cover;
+  height: 100%;
 }
 
 .app-main {

--- a/src/Genre/Genre.scss
+++ b/src/Genre/Genre.scss
@@ -1,0 +1,17 @@
+.genre {
+  display: flex;
+  flex-wrap: wrap;
+  padding: .5rem;
+
+  button {
+    color: black;
+    border-radius: 1rem;
+    font-size: 1.2rem;
+    transition: .4s all;
+
+    &:hover {
+      cursor: pointer;
+      transform: scale(1.1);
+    }
+  }
+}

--- a/src/Genre/Genre.tsx
+++ b/src/Genre/Genre.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import './Genre.scss';
+
 interface IProps {
 	updateSelectedGenre: (genre: string) => void;
 	genre: string;
@@ -8,12 +10,13 @@ interface IProps {
 function Genre(props: IProps) {
 	return (
 		<section className='genre'>
-			<h1
+			<button 
+				type='button'
 				onClick={event =>
 					props.updateSelectedGenre(event.currentTarget.innerHTML)
 				}>
 				{props.genre}
-			</h1>
+			</button>
 		</section>
 	);
 }

--- a/src/GenresList/GenresList.scss
+++ b/src/GenresList/GenresList.scss
@@ -1,0 +1,8 @@
+.genre-list {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 95vh;
+  width: 20vw;
+  overflow: scroll;
+}

--- a/src/GenresList/GenresList.tsx
+++ b/src/GenresList/GenresList.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React from 'react';
 
-import Genre from '../Genre/Genre'
+import Genre from '../Genre/Genre';
+
+import './GenresList.scss'
 
 interface IProps {setAppGenre: (genre: string) => void, genres: string[]}
 
@@ -18,7 +20,7 @@ function GenresList(props: IProps) {
   }
 
   return (
-    <section>
+    <section className='genre-list'>
       {renderGenres()}
     </section>
   )

--- a/src/PlaylistContainer/PlaylistContainer.scss
+++ b/src/PlaylistContainer/PlaylistContainer.scss
@@ -2,8 +2,8 @@
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  width: 90vw;
+  width: 80vw;
   height: 80vh;
-  margin-left: 10rem;
+  margin-left: 5rem;
   overflow: scroll;
 }


### PR DESCRIPTION
### What’s this PR do?  
- Adjusted styling between GenreList and PlaylistContainer to give each other proper screen spacing.
- Adds styling for GenreList and Genre components.
- Adjusts styling for App to extend vertically the full length of the screen without cutting off.
 
### Where should the reviewer start?  
- Git pull this branch.
- App.scss, GenreList.scss, PlaylistContainer.scss, Genre.tsx.
 
### How should this be manually tested?  
- run `npm start` and navigate to localhost:3000.
- Click on the genre buttons to ensure that it is still generating playlists correctly.
- Ensure that Genres and GeneratedPlaylists does not break the graphic at the bottom of the page with white filler.
 
### Any background context you want to provide?  
- N/A
 
### What are the relevant tickets?  
- closes #93
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A