### PR TITLE
Testing cleanup

### DIFF
--- a/src/GeneratedPlaylists/GeneratedPlaylist.test.tsx
+++ b/src/GeneratedPlaylists/GeneratedPlaylist.test.tsx
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
 describe('GeneratedPlaylist', () => {
   const mockToggleSaved = jest.fn()
   const playlist1 = {
-    id: 1,
+    id: 0,
     name: 'military western ska',
     isSaved: false,
     tracks: [
@@ -57,7 +57,7 @@ describe('GeneratedPlaylist', () => {
   beforeEach(() =>
 		render(
       <MemoryRouter>
-        <GeneratedPlaylist selectedGenre={selectedGenre} playlist={playlist1} toggleSaved={mockToggleSaved}/>
+        <GeneratedPlaylist playlistIndex={0} selectedGenre={selectedGenre} playlist={playlist1} toggleSaved={mockToggleSaved}/>
       </MemoryRouter>
 		)
   );
@@ -75,7 +75,7 @@ describe('GeneratedPlaylist', () => {
   test('should have saved icon with a saved playlist', () => {
     render(
       <MemoryRouter>
-        <GeneratedPlaylist selectedGenre={selectedGenre} playlist={playlist2} toggleSaved={mockToggleSaved}/>
+        <GeneratedPlaylist playlistIndex={0} selectedGenre={selectedGenre} playlist={playlist2} toggleSaved={mockToggleSaved}/>
       </MemoryRouter>
 		)
     expect(screen.getByAltText('Unsave playlist')).toBeInTheDocument()

--- a/src/Genre/Genre.test.tsx
+++ b/src/Genre/Genre.test.tsx
@@ -25,7 +25,7 @@ describe('Genre', () => {
 	});
 
 	test('should update selected genre when clicked', () => {
-		userEvent.click(screen.getByRole('heading', { name: 'jesus funk' }));
+		userEvent.click(screen.getByRole('button', { name: 'jesus funk' }));
 		expect(mockSelectedGenre).toHaveBeenCalledTimes(1);
 		expect(mockSelectedGenre).toHaveBeenCalledWith('jesus funk');
 	});


### PR DESCRIPTION
### What’s this PR do?  
* Fixes testing in Genre to make getByRole look for a button after PR #94 refactored h1s to button tags.
* Fixes GeneratedPlaylist testing to take in a prop of playlistIndex after PR #96 refactored GeneratedPlaylist props.
 
### Where should the reviewer start?  
Operate in the test files for `src/GeneratedPlaylist` and `src/Genre`
 
### How should this be manually tested?  
npm test
 
### Any background context you want to provide?  
N/A
 
### What are the relevant tickets?  
Closes #97
Closes #98
 
### Screenshots (if appropriate)  
N/A
 
### Questions: 
N/A