### PR TITLE
Nd playlist details style

### DIFF
--- a/src/App/App.scss
+++ b/src/App/App.scss
@@ -5,11 +5,11 @@
   align-items: center;
   background: url(../images/main-background.jpg) no-repeat center;
   background-size: cover;
-  height: 100%;
-}
+  min-height: 100vh;
 
-.app-main {
-  display: flex;
-  justify-content: space-between;
-  width: 95vw;
+  .app-main {
+    display: flex;
+    justify-content: space-between;
+    width: 95vw;
+  }
 }

--- a/src/PlaylistDetails/PlaylistDetails.scss
+++ b/src/PlaylistDetails/PlaylistDetails.scss
@@ -1,0 +1,44 @@
+.playlist-details {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: auto;
+  place-items: left;
+  width: 90vw;
+  border: .1rem solid white;
+  border-radius: 1rem;
+  background-color: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+
+  .playlist-name {
+    font-size: 2.2rem;
+  }
+
+  .playlist-details-head {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    grid-column: span 4;
+
+    img {
+      width: 1.5rem;
+      margin-left: 1rem;
+    }
+  }
+
+  .playlist-details-body {
+    margin: 1rem;
+
+    .artist-name {
+      font-size: 1.6rem;
+    }
+
+    .playlist-details-url {
+      display: flex;
+      flex-direction: column;
+
+      a {
+        margin: .5rem 0;
+      }
+    }
+  }
+}

--- a/src/PlaylistDetails/PlaylistDetails.tsx
+++ b/src/PlaylistDetails/PlaylistDetails.tsx
@@ -16,15 +16,13 @@ const displaySongs = (playlist: Playlist) => {
   return playlist.tracks.reduce((finalSongs: JSX.Element[], currentSong, index: number): JSX.Element[] => {
       const songToDisplay = 
         <section key={index} className='playlist-details-body'>
-          <section className="artist-left">
-            <h3>{currentSong.songName}</h3>
-            <h3>{currentSong.artist.name}</h3>
-          </section>
-          <section className="artist-right">
+          <h3 className='artist-name'>{currentSong.songName}</h3>
+          <h3>By: {currentSong.artist.name}</h3>
+          <article className="playlist-details-url">
             <a data-testid={`song-url-${index}`} target='_blank' rel='noreferrer' href={currentSong.songUrl}>View song on Last FM</a>
             <a data-testid={`artist-url-${index}`}target='_blank' rel='noreferrer' href={currentSong.artist.artistUrl}>View Artist on Last FM</a>
-          </section>
-        </section>;
+          </article>
+        </section>
       finalSongs.push(songToDisplay)
     return finalSongs
   }, [])
@@ -34,7 +32,7 @@ const PlaylistDetails = (props: IProps) => {
   return (
     <section className="playlist-details">
       <article className='playlist-details-head'>
-				<Link to={`/playlist/${props.playlist.id}`}>{props.playlist.name}</Link>
+        <Link to={`/playlist/${props.playlist.id}`}><h1 className='playlist-name'>{props.playlist.name}</h1></Link>
 				<img
 					src={props.playlist.isSaved ? savedPlaylist : unSavedPlaylist}
 					className='save'
@@ -42,7 +40,6 @@ const PlaylistDetails = (props: IProps) => {
 					onClick={() => props.toggleSaved(props.playlist)}
 				/>
 			</article>
-      <h1>{props.playlist.name}</h1>
       {displaySongs(props.playlist)}
     </section>
   )

--- a/src/PlaylistDetails/PlaylistDetails.tsx
+++ b/src/PlaylistDetails/PlaylistDetails.tsx
@@ -15,11 +15,15 @@ interface IProps { playlist: any, toggleSaved: (playlist: Playlist) => void; }
 const displaySongs = (playlist: Playlist) => {
   return playlist.tracks.reduce((finalSongs: JSX.Element[], currentSong, index: number): JSX.Element[] => {
       const songToDisplay = 
-        <section key={index}>
-          <h3>{currentSong.songName}</h3>
-          <h3>{currentSong.artist.name}</h3>
-          <a data-testid={`song-url-${index}`} target='_blank' rel='noreferrer' href={currentSong.songUrl}>View song on Last FM</a>
-          <a data-testid={`artist-url-${index}`}target='_blank' rel='noreferrer' href={currentSong.artist.artistUrl}>View Artist on Last FM</a>
+        <section key={index} className='playlist-details-body'>
+          <section className="artist-left">
+            <h3>{currentSong.songName}</h3>
+            <h3>{currentSong.artist.name}</h3>
+          </section>
+          <section className="artist-right">
+            <a data-testid={`song-url-${index}`} target='_blank' rel='noreferrer' href={currentSong.songUrl}>View song on Last FM</a>
+            <a data-testid={`artist-url-${index}`}target='_blank' rel='noreferrer' href={currentSong.artist.artistUrl}>View Artist on Last FM</a>
+          </section>
         </section>;
       finalSongs.push(songToDisplay)
     return finalSongs

--- a/src/PlaylistDetails/PlaylistDetails.tsx
+++ b/src/PlaylistDetails/PlaylistDetails.tsx
@@ -18,8 +18,8 @@ const displaySongs = (playlist: Playlist) => {
         <section key={index}>
           <h3>{currentSong.songName}</h3>
           <h3>{currentSong.artist.name}</h3>
-          <a data-testid={`song-url-${index}`} target='_blank' href={currentSong.songUrl}>View song on Last FM</a>
-          <a data-testid={`artist-url-${index}`}target='_blank' href={currentSong.artist.artistUrl}>View Artist on Last FM</a>
+          <a data-testid={`song-url-${index}`} target='_blank' rel='noreferrer' href={currentSong.songUrl}>View song on Last FM</a>
+          <a data-testid={`artist-url-${index}`}target='_blank' rel='noreferrer' href={currentSong.artist.artistUrl}>View Artist on Last FM</a>
         </section>;
       finalSongs.push(songToDisplay)
     return finalSongs


### PR DESCRIPTION
### What’s this PR do?  
- Adds styling to PlaylistDetails component.
- Adds additional structure to PlaylistDetails to allow for styling.
- Adds `rel='noreferrer'` to remove warning about security risk using `target='_blank'` without it.
- Adjust height for App-main to ensure background photo covers entire screen in both views.
 
### Where should the reviewer start?  
- Git pull this branch.
- Working out of App.scss, PlaylistDetails.tsx and PlaylistDetails.scss.
 
### How should this be manually tested?  
- run `npm start` and navigate to localhost:3000
- Add a playlist by clicking on a genre button.
- Click on the title of that playlist to navigate to PlaylistDetails page. 
- Ensure everything displays properly without breaking graphics on the screen.
- Ensure a user is able to save a playlist from PlaylistDetails page
- Navigate to View Saved route to make sure that it shows up in saved page.
 
### Any background context you want to provide?  
- Additional finalizing of styling details will be reviewed as a group and get increasing more user feedback when certain actions can be perfomed.
 
### What are the relevant tickets?  
- closes #101 
- closes #76 
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A