### PR TITLE
Add test for removing a saved playlist in the saved view

### DIFF
--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -152,6 +152,24 @@ describe('App', () => {
     expect(playlistToCheck).toBeInTheDocument();
   });
 
+  test('should be able to remove a saved a playlist while in the saved route and see it disappear', async () => {
+    (getGenres as jest.Mock).mockResolvedValue(mockGenres);
+    (getPlaylist as jest.Mock).mockResolvedValue(mockPlaylist1);
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+    const genreToClick: HTMLElement = await waitFor(() => screen.getByText('military western ska'))
+    userEvent.click(screen.getByText(genreToClick.innerHTML))
+    const firstStarToClick = await waitFor(() => screen.getByTestId('playlist-star-0'))
+    userEvent.click(firstStarToClick)
+    userEvent.click(screen.getByText('View Saved'))
+    const secondStarToClick = await waitFor(() => screen.getByTestId('playlist-star-0'))
+    userEvent.click(secondStarToClick)
+    expect(screen.getByText('Add a playlist!')).toBeInTheDocument();
+  });
+
   test('should be able to navigate to playlist details page after creating a playlist', async () => {
     (getGenres as jest.Mock).mockResolvedValue(mockGenres);
     (getPlaylist as jest.Mock).mockResolvedValue(mockPlaylist1);


### PR DESCRIPTION
### What’s this PR do?  
* Tests that after saving a playlist and navigating to the saved view, clicking the unsave button makes the playlist disappear from the saved view
 
### Where should the reviewer start?  
src/App/App.test.tsx
 
### How should this be manually tested?  
npm test
 
### Any background context you want to provide?  
N/A
 
### What are the relevant tickets?  
Closes #113 
 
### Screenshots (if appropriate)  
N/A
 
### Questions: 
N/A