### PR TITLE
Remove duration from cleaned API data

### DIFF
--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -34,7 +34,6 @@ describe('App', () => {
             "name": "Sublime",
             "artistUrl": "https://www.last.fm/music/Sublime"
           },
-          "duration": "208",
           "songName": "Smoke Two",
           "songUrl": "https://www.last.fm/music/Sublime/_/Smoke+Two+Joints"
         },
@@ -44,7 +43,6 @@ describe('App', () => {
             "name": "Pat Metheny Group",
             "artistUrl": "https://www.last.fm/music/Pat+Metheny+Group"
           },
-          "duration": "167",
           "songName": "Forward March",
           "songUrl": "https://www.last.fm/music/Pat+Metheny+Group/_/Forward+March"
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,6 @@ export interface CleanedAlbumTrack {
     name: string,
     artistUrl: string
   },
-  duration: string,
   songName: string,
   songUrl: string,
 }
@@ -43,7 +42,6 @@ export const cleanGenreTrackData = (track: AlbumTrack): CleanedAlbumTrack => {
       name: track.artist.name,
       artistUrl: track.artist.url
     },
-    duration: track.duration,
     songName: track.name,
     songUrl: track.url
   }


### PR DESCRIPTION
### What’s this PR do?  
Removes `duration` property from cleaned Last FM API data
 
### Where should the reviewer start?  
src/utils.ts
 
### How should this be manually tested?  
console log a playlist and generate one in the browser. See that the generated playlist object in the browser terminal does not have the property of `duration`
 
### Any background context you want to provide?  
N/A
 
### What are the relevant tickets?  
Closes #49 
 
### Screenshots (if appropriate)  
N/A
 
### Questions: 
N/A