### PR TITLE
Add secure URL in Last FM API call

### DIFF
--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -1,6 +1,6 @@
 import { cleanGenreTrackData, Playlist, AlbumTrack, randomizeSongs } from './utils/utils'
 
-const apiUrl = `http://ws.audioscrobbler.com/2.0/?method=tag.gettoptracks&tag=`;
+const apiUrl = `https://ws.audioscrobbler.com/2.0/?method=tag.gettoptracks&tag=`;
 
 export const getGenres = () => {
   return (


### PR DESCRIPTION
### What’s this PR do?  
Adds secure URL in Last FM API call
 
### Where should the reviewer start?  
src/apiCalls.ts
 
### How should this be manually tested?  
* npm start, 
* Click a genre and make sure that a playlist is generated
 
### Any background context you want to provide?  
Heroku doesn't like non-secure APIs being called from a secure deployed website.
 
### What are the relevant tickets?  
Closes #25
 
### Screenshots (if appropriate)  
N/A
 
### Questions: 
N/A