### PR TITLE
Nd fetch error msgs

### DIFF
--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -212,4 +212,18 @@ describe('App', () => {
     const failMessage = await waitFor(() => screen.getByText('We were not able to fetch the genres. Refresh the page to try again.'))
     expect(failMessage).toBeInTheDocument();
   });
+
+  test('should return a failed message if fetch call for GeneratedPlaylist fails', async () => {
+    (getGenres as jest.Mock).mockResolvedValue(mockGenres);
+    (getPlaylist as jest.Mock).mockResolvedValue('error');
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+    const genreToClick: HTMLElement = await waitFor(() => screen.getByText('military western ska'))
+    userEvent.click(genreToClick);
+    const failMessage = await waitFor(() => screen.getByText('We were not able to fetch any playlist. Please refresh the page to try again.'));
+    expect(failMessage).toBeInTheDocument();
+  });
 });

--- a/src/App/App.test.tsx
+++ b/src/App/App.test.tsx
@@ -201,4 +201,15 @@ describe('App', () => {
     userEvent.click(screen.getByText('View Saved'))
     expect(screen.getByText('military western ska')).toBeInTheDocument()
   });
+
+  test('should return a failed message if fetch call for genres fails', async () => {
+    (getGenres as jest.Mock).mockResolvedValue('error');
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+    const failMessage = await waitFor(() => screen.getByText('We were not able to fetch the genres. Refresh the page to try again.'))
+    expect(failMessage).toBeInTheDocument();
+  });
 });

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -44,7 +44,9 @@ class App extends Component<IProps, IState> {
 		this.setState({ selectedGenre: genre });
 		const splitGenreArray = this.parseGenreForFetch(genre);
 		getPlaylist(splitGenreArray).then(data => {
-			if (data.tracks.length) {
+			if (data === 'error') {
+				this.setState({ error: 'We were not able to fetch any playlist. Please refresh the page to try again.'})
+			} else if (data.tracks.length) {
 				this.setState({ playlists: [...this.state.playlists, data], error: "" })
 			} else {
 				this.setState({ error: "This genre didn't find any songs!" })

--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -31,7 +31,13 @@ class App extends Component<IProps, IState> {
 	}
 
 	componentDidMount = () => {
-		getGenres().then(data => this.setState({ genres: data }));
+		getGenres().then(data => {
+			if (data === 'error') {
+				this.setState({ error: 'We were not able to fetch the genres. Refresh the page to try again.' });
+			} else {
+				this.setState({ genres: data, error: '' });
+			}
+		});
 	};
 
 	setAppGenre = (genre: string) => {

--- a/src/PlaylistDetails/PlaylistDetails.scss
+++ b/src/PlaylistDetails/PlaylistDetails.scss
@@ -61,6 +61,7 @@
 
         &:hover {
           @include skyblue-hover();
+          border-bottom: none;
           text-decoration: underline;
         }
       }

--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -5,7 +5,14 @@ const apiUrl = `http://ws.audioscrobbler.com/2.0/?method=tag.gettoptracks&tag=`;
 export const getGenres = () => {
   return (
     fetch('https://binaryjazz.us/wp-json/genrenator/v1/genre/25')
-      .then(response => response.json()) 
+      .then(response => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw Error
+        }
+      })
+      .catch(() => 'error')
   )
 }
 

--- a/src/apiCalls.ts
+++ b/src/apiCalls.ts
@@ -16,12 +16,18 @@ export const getGenres = () => {
   )
 }
 
-export const getPlaylist = (genreArray: string[]) => {
+export const getPlaylist = (genreArray: string[]): Promise<any> => {
   return (
     Promise.all(
       genreArray.map(genre => {
         return fetch(`${apiUrl}${genre}&api_key=${process.env.REACT_APP_LASTFM_APIKEY}&limit=100&format=json`)
-          .then(response => response.json())
+          .then(response => {
+            if(response.ok) {
+              return response.json()
+            } else {
+              throw Error
+            }
+          })
       })
     )
     .then(data => {
@@ -39,5 +45,6 @@ export const getPlaylist = (genreArray: string[]) => {
       combinedPlaylist.tracks = randomPlaylist.filter((_playlist, index) => index < 15);
       return combinedPlaylist;
     })
+    .catch(() => 'error')
   )
 }


### PR DESCRIPTION
### What’s this PR do?  
- Adds rendering to the user if getGenres and/or getPlaylist fetch calls fail.
- Fixes graphical bug where PlaylistDetails artist and song external links displayed across entire grid.
- Added 2 more tests for conditional rendering when fetch calls fail.
 
### Where should the reviewer start?  
- git pull this branch.
- App.tsx, apiCalls.ts, PlaylistDetails.tsx
 
### How should this be manually tested?  
- `npm start` navigate to localhost:3000
- break a fetch call in apiCalls file.
- Ensure that both apiCalls are rendering error messages if something goes wrong.
- Hover over artist and song external links on PlaylistDetails to make sure only the words stay underlined.
- `npm test` to ensure all tests pass.
 
### Any background context you want to provide?  
- N/A
 
### What are the relevant tickets?  
- closes #128
- closes #129
- closes #130
 
### Screenshots (if appropriate)  
- N/A
 
### Questions: 
- N/A